### PR TITLE
Fix code scanning alert no. 6: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -161,12 +161,13 @@ class HTTPDigestAuth(AuthBase):
             hash_utf8 = argon2_hash
         elif _algorithm == "SHA-256":
 
-            def sha256_utf8(x):
+            def argon2_hash(x):
+                ph = PasswordHasher()
                 if isinstance(x, str):
                     x = x.encode("utf-8")
-                return hashlib.sha256(x).hexdigest()
+                return ph.hash(x)
 
-            hash_utf8 = sha256_utf8
+            hash_utf8 = argon2_hash
         elif _algorithm == "SHA-512":
 
             def argon2_hash(x):


### PR DESCRIPTION
Fixes [https://github.com/akaday/requests/security/code-scanning/6](https://github.com/akaday/requests/security/code-scanning/6)

To fix the problem, we need to replace the use of SHA-256 with a more secure and computationally expensive hashing algorithm suitable for passwords. Argon2 is a good choice for this purpose. We will replace the SHA-256 hashing function with Argon2 in the relevant part of the code.

- Replace the `sha256_utf8` function with an `argon2_hash` function.
- Ensure that the `argon2_hash` function is used consistently in place of `sha256_utf8`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
